### PR TITLE
chore(security): pin GitHub Actions to commit SHA

### DIFF
--- a/.github/workflows/automerge-dependabot.yml
+++ b/.github/workflows/automerge-dependabot.yml
@@ -6,7 +6,7 @@ jobs:
     runs-on: ubuntu-latest
     if: github.actor == 'dependabot[bot]'
     steps:
-      - uses: peter-evans/enable-pull-request-automerge@v3
+      - uses: peter-evans/enable-pull-request-automerge@a660677d5469627102a1c1e11409dd063606628d # v3
         with:
           token: ${{ secrets.ACTIONS_BOT_TOKEN }}
           pull-request-number: ${{ github.event.pull_request.number }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,8 +19,8 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-node@v3
+      - uses: actions/checkout@a37ce9120846195fa4ece8f58b268e6043cb2f26 # v3
+      - uses: actions/setup-node@3235b876344d2a9aa001b8d1453c930bba69e610 # v3
         with:
           node-version: 16.x
       - run: npm ci
@@ -28,11 +28,11 @@ jobs:
       - run: npm run format-check
       - run: npm run lint
       - run: npm run test
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@ff15f0306b3f739f7b6fd43fb5d26cd321bd4de5 # v3
         with:
           name: dist
           path: dist
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@ff15f0306b3f739f7b6fd43fb5d26cd321bd4de5 # v3
         with:
           name: action.yml
           path: action.yml
@@ -45,14 +45,14 @@ jobs:
       matrix:
         target: [built, committed]
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@a37ce9120846195fa4ece8f58b268e6043cb2f26 # v3
       - if: matrix.target == 'built' || github.event_name == 'pull_request'
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47d8a # v3
         with:
           name: dist
           path: dist
       - if: matrix.target == 'built' || github.event_name == 'pull_request'
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47d8a # v3
         with:
           name: action.yml
           path: .
@@ -73,13 +73,13 @@ jobs:
     needs: [test]
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/download-artifact@v3
+      - uses: actions/checkout@a37ce9120846195fa4ece8f58b268e6043cb2f26 # v3
+      - uses: actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47d8a # v3
         with:
           name: dist
           path: dist
       - name: Create Pull Request
-        uses: peter-evans/create-pull-request@v5
+        uses: peter-evans/create-pull-request@4e1beaa7521e8b457b572c090b25bd3db56bf1c5 # v5
         with:
           token: ${{ secrets.ACTIONS_BOT_TOKEN }}
           commit-message: Update distribution

--- a/.github/workflows/on-repository-dispatch.yml
+++ b/.github/workflows/on-repository-dispatch.yml
@@ -11,7 +11,7 @@ jobs:
           PAYLOAD_CONTEXT: ${{ toJson(github.event.client_payload) }}
         run: echo "$PAYLOAD_CONTEXT"
 
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@a37ce9120846195fa4ece8f58b268e6043cb2f26 # v3
         if: github.event.client_payload.ref != ''
         with:
           ref: ${{ github.event.client_payload.ref }}

--- a/.github/workflows/slash-command-dispatch.yml
+++ b/.github/workflows/slash-command-dispatch.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Slash Command Dispatch
-        uses: peter-evans/slash-command-dispatch@v3
+        uses: peter-evans/slash-command-dispatch@f996d7b7aae9059759ac55e978cff76d91853301 # v3
         with:
           token: ${{ secrets.ACTIONS_BOT_TOKEN }}
           config: >

--- a/.github/workflows/test-dispatch.yml
+++ b/.github/workflows/test-dispatch.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Test repository dispatch
-        uses: peter-evans/repository-dispatch@v2
+        uses: peter-evans/repository-dispatch@bf47d102fdb849e755b0b0023ea3e81a44b6f570 # v2
         with:
           # token: ${{ secrets.PUBLIC_REPO_SCOPED_TOKEN }}
           event-type: tests

--- a/.github/workflows/update-major-version.yml
+++ b/.github/workflows/update-major-version.yml
@@ -17,7 +17,7 @@ jobs:
   tag:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@a37ce9120846195fa4ece8f58b268e6043cb2f26 # v3
       with:
         token: ${{ secrets.ACTIONS_BOT_TOKEN }}
         fetch-depth: 0


### PR DESCRIPTION
Pins GitHub Actions in this repo to immutable commit SHAs (with the original tag kept as a comment) to close a supply-chain risk gap — part of the org-wide SHA pinning initiative (GST-2062).

This is a one-time manual fix; this repo does not currently have Renovate managing action pins. No functional changes — CI should behave identically.